### PR TITLE
Add options to define input and content glob pattern for tailwind

### DIFF
--- a/bin/bundler.js
+++ b/bin/bundler.js
@@ -7,11 +7,19 @@ const fs = require("fs");
 const { build } = require("../src/build");
 
 async function main() {
-  const input = "src/main.js";
-
   try {
     const args = util.parseArgs({
       options: {
+        input: {
+          type: "string",
+          default: "src/main.js",
+        },
+        "tailwind-content-glob": {
+          type: "string",
+          default: ["./src/**/*.js"],
+          multiple: true,
+          short: "c",
+        },
         outdir: {
           type: "string",
         },
@@ -26,9 +34,9 @@ async function main() {
       },
     });
 
-    if (!fs.existsSync(input)) {
+    if (!fs.existsSync(args.values.input)) {
       throw new Error(
-        "Expected src/main.js to exist, but no such file has been found",
+        `Expected ${args.values.input} to exist, but no such file has been found`
       );
     }
 
@@ -38,8 +46,9 @@ async function main() {
 
     const outdir = args.values.outdir;
     const options = { prod: !args.values.dev, watch: args.values.watch };
+    const tailwindContentGlob = args.values["tailwind-content-glob"];
 
-    await build(input, outdir, options);
+    await build(args.values.input, outdir, tailwindContentGlob, options);
     process.exit(0);
   } catch (error) {
     console.error(error.message);

--- a/src/build.js
+++ b/src/build.js
@@ -5,12 +5,13 @@ const stylePlugin = require("esbuild-style-plugin");
 const tailwind = require("tailwindcss");
 const autoprefixer = require("autoprefixer");
 
-const tailwindConfig = require("../tailwind.config.js");
+const tailwindBaseConfig = require("../tailwind.config.js");
 
 module.exports.build = async function (
   input,
   outdir,
-  { prod = true, watch = false } = {},
+  tailwindContentGlob,
+  { prod = true, watch = false } = {}
 ) {
   if (fs.existsSync(outdir)) {
     const mainOutputName = path.basename(input);
@@ -21,11 +22,15 @@ module.exports.build = async function (
       fs.rmSync(outdir, { recursive: true, force: true });
     } else {
       throw new Error(
-        `The output directory is not empty, but does not contain ${mainOutputName}. Are you sure you specified the right output directory? If you are sure, then remove the output directory manually and run the build again.`,
+        `The output directory is not empty, but does not contain ${mainOutputName}. Are you sure you specified the right output directory? If you are sure, then remove the output directory manually and run the build again.`
       );
     }
   }
 
+  const tailwindConfig = {
+    ...tailwindBaseConfig,
+    content: tailwindContentGlob,
+  };
   const ctx = await esbuild.context({
     entryPoints: [input],
     outdir: outdir,


### PR DESCRIPTION
Hey, I love this module! But could we allow a bit more flexible in directory structure? When I create multiple smart cells in one kino library but want to share some elements (e.g. form elements) via a shared folder, this setup doesn't work. 

The approach is simple: allow users to pass options for `--input` and `--tailwind-content-glob` (or `-c`, multiple entries are possible). The defaults for the new options are set to the values that were hardcoded before, so this change shouldn't break compatibility.